### PR TITLE
luxwslang: Parse "---" as value zero

### DIFF
--- a/luxwslang/terminology.go
+++ b/luxwslang/terminology.go
@@ -89,6 +89,16 @@ func (*Terminology) ParseMeasurement(text string) (float64, string, error) {
 			}
 		}
 
+		if !ok {
+			for _, format := range []string{"--- %s\n", "---%s\n"} {
+				if n, err := fmt.Sscanf(text, format, &unit); err == nil && n == 1 {
+					value = 0
+					ok = true
+					break
+				}
+			}
+		}
+
 		if ok {
 			switch unit {
 			case "K", "bar", "l/h", "kWh", "rpm", "V", "kW", "Hz", "mA", "s", "m³/h":

--- a/luxwslang/terminology_test.go
+++ b/luxwslang/terminology_test.go
@@ -142,6 +142,8 @@ func TestParseMeasurement(t *testing.T) {
 		{terms: English, input: "3600s", want: 3600, wantUnit: "s"},
 		{terms: English, input: "36 m³/h", want: 36, wantUnit: "m³/h"},
 		{terms: English, input: "18 min", want: 18 * 60, wantUnit: "s"},
+		{terms: Dutch, input: "--- l/h", want: 0, wantUnit: "l/h"},
+		{terms: English, input: "---rpm", want: 0, wantUnit: "rpm"},
 	} {
 		t.Run(tc.terms.ID+" "+tc.input, func(t *testing.T) {
 			got, gotUnit, err := tc.terms.ParseMeasurement(tc.input)


### PR DESCRIPTION
When there is no demand for heat, the circulation pump stops pumping water around. The heat pump UI shows "--- l/h" as the flow rate (liters per hour).