### PR TITLE
Skip rows without timestamp when parsing reported errors

### DIFF
--- a/luxws-exporter/collector.go
+++ b/luxws-exporter/collector.go
@@ -253,7 +253,7 @@ func (c *collector) collectTimetable(ch chan<- prometheus.Metric, desc *promethe
 		reason := normalizeSpace(*item.Value)
 
 		// Use only the most recent timestamp per reason
-		if prev, ok := latest[reason]; !ok || prev.IsZero() || prev.Before(ts) {
+		if prev := latest[reason]; prev.IsZero() || prev.Before(ts) {
 			latest[reason] = ts
 		}
 	}

--- a/luxws-exporter/collector.go
+++ b/luxws-exporter/collector.go
@@ -241,11 +241,13 @@ func (c *collector) collectTimetable(ch chan<- prometheus.Metric, desc *promethe
 	latest := map[string]time.Time{}
 
 	for _, item := range group.Items {
-		if item.Value == nil {
+		tsRaw := normalizeSpace(item.Name)
+
+		if item.Value == nil || strings.Trim(tsRaw, "-") == "" {
 			continue
 		}
 
-		ts, err := c.terms.ParseTimestamp(item.Name, c.loc)
+		ts, err := c.terms.ParseTimestamp(tsRaw, c.loc)
 		if err != nil {
 			return err
 		}

--- a/luxws-exporter/collector_test.go
+++ b/luxws-exporter/collector_test.go
@@ -367,6 +367,27 @@ luxws_latest_error{reason="bbb"} 1396566000
 `,
 		},
 		{
+			name: "latest error with empty rows",
+			fn:   c.collectLatestError,
+			input: &luxwsclient.ContentRoot{
+				Items: []luxwsclient.ContentItem{
+					{
+						Name: "Fehlerspeicher",
+						Items: []luxwsclient.ContentItem{
+							{Name: "----", Value: luxwsclient.String("placeholder")},
+							{Name: "08.11.21 21:40:09", Value: luxwsclient.String("text")},
+							{Name: "----", Value: luxwsclient.String("----")},
+						},
+					},
+				},
+			},
+			want: `
+# HELP luxws_latest_error Latest error
+# TYPE luxws_latest_error gauge
+luxws_latest_error{reason="text"} 1636407609
+`,
+		},
+		{
 			name: "latest switch-off empty",
 			fn:   c.collectLatestSwitchOff,
 			input: &luxwsclient.ContentRoot{


### PR DESCRIPTION
The table with errors encountered by the heat pump controller may contain empty rows, denoted by `----`.
