### PR TITLE
fix: added "enum" as a possible unit

### DIFF
--- a/luxwslang/terminology.go
+++ b/luxwslang/terminology.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -117,6 +118,16 @@ func (*Terminology) ParseMeasurement(text string) (float64, string, error) {
 
 			return value, unit, nil
 		}
+	}
+
+	if _, err := strconv.Atoi(text); err == nil && len(text) == 1 {
+		var value float64
+		var unit string
+
+		unit = "enum"
+		value, _ = strconv.ParseFloat(text, 64)
+
+		return value, unit, nil
 	}
 
 	return 0, "", fmt.Errorf("unrecognized measurement format %q", text)

--- a/luxwslang/terminology_test.go
+++ b/luxwslang/terminology_test.go
@@ -138,6 +138,7 @@ func TestParseMeasurement(t *testing.T) {
 		{terms: German, input: "100000 kWh", want: 100000, wantUnit: "kWh"},
 		{terms: German, input: "1 kW", want: 1, wantUnit: "kW"},
 		{terms: German, input: "16.66 Hz", want: 16.66, wantUnit: "Hz"},
+		{terms: German, input: "2", want: 2, wantUnit: "enum"},
 		{terms: English, input: "200 mA", want: 200, wantUnit: "mA"},
 		{terms: English, input: "3600s", want: 3600, wantUnit: "s"},
 		{terms: English, input: "36 m³/h", want: 36, wantUnit: "m³/h"},

--- a/luxwslang/terminology_test.go
+++ b/luxwslang/terminology_test.go
@@ -122,7 +122,7 @@ func TestParseMeasurement(t *testing.T) {
 		wantErr  bool
 	}{
 		{terms: German, input: "", wantErr: true},
-		{terms: German, input: "1.23", wantErr: true},
+		{terms: German, input: "1.23", want: 1.23},
 		{terms: German, input: "100m", wantErr: true},
 		{terms: German, input: "1l", wantErr: true},
 		{terms: German, input: "1.11°C", want: 1.11, wantUnit: "degC"},
@@ -138,11 +138,12 @@ func TestParseMeasurement(t *testing.T) {
 		{terms: German, input: "100000 kWh", want: 100000, wantUnit: "kWh"},
 		{terms: German, input: "1 kW", want: 1, wantUnit: "kW"},
 		{terms: German, input: "16.66 Hz", want: 16.66, wantUnit: "Hz"},
-		{terms: German, input: "2", want: 2, wantUnit: "enum"},
+		{terms: German, input: "2", want: 2},
 		{terms: English, input: "200 mA", want: 200, wantUnit: "mA"},
 		{terms: English, input: "3600s", want: 3600, wantUnit: "s"},
 		{terms: English, input: "36 m³/h", want: 36, wantUnit: "m³/h"},
 		{terms: English, input: "18 min", want: 18 * 60, wantUnit: "s"},
+		{terms: English, input: "3.14", want: 3.14},
 		{terms: Dutch, input: "--- l/h", want: 0, wantUnit: "l/h"},
 		{terms: English, input: "---rpm", want: 0, wantUnit: "rpm"},
 	} {


### PR DESCRIPTION
This is a fix for https://github.com/hansmi/wp2reg-luxws/issues/51 - obviously I have no idea what I'm doing, but nothing else returned in the XML from the Novelan seems to be a one digit thing containing a discrete set of states encoded as an integer, so, works for me.